### PR TITLE
inference.py now runs successfully

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - defaults
   - salilab
 dependencies:
-  - python=3.8
+  - python=3.9
   - pytorch 1.10
   - dgl-cuda11.1
   - torchvision

--- a/inference.py
+++ b/inference.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 from shutil import rmtree
 from pathlib import Path
 import logging
-from aem import con
 
 import torch
 from joblib import Parallel, delayed


### PR DESCRIPTION
Hello everyone! 

1) There was an issue #4, so I fixed file `inference.py`
2) `inference.py` does not run with `python=3.8` in `environment.yml`, because types are not subscriptable. For example, this line caused an error: https://github.com/BioinfoMachineLearning/DProQ/blob/be5c85e4c74aca04abd161063498de848de5e001/src/utils.py#L116
So I have set python version to `3.9` and inference now works.